### PR TITLE
fix(server): stop baking .env into the server image

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -39,7 +39,6 @@ jobs:
       - name: Copy environment files
         run: |
           echo "${{ secrets.CLIENT_ENV }}" > apps/client/.env
-          echo "${{ secrets.SERVER_ENV }}" > apps/server/.env
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5

--- a/docker/Dockerfile-server
+++ b/docker/Dockerfile-server
@@ -53,7 +53,6 @@ COPY --from=builder /bus-tracker/server-deployment/node_modules ./node_modules/
 COPY --from=builder /bus-tracker/server-deployment/drizzle ./drizzle/
 COPY --from=builder /bus-tracker/server-deployment/dist ./dist/
 COPY --from=builder /bus-tracker/server-deployment/package.json ./package.json
-COPY --from=builder /bus-tracker/server-deployment/.env ./.env
 
 USER node
 ENTRYPOINT ["/sbin/tini", "--"]


### PR DESCRIPTION
The server image copied apps/server/.env into the final layer, exposing every production secret to anyone who could pull it. The runtime never used the file anyway (entrypoint runs `node dist/index.js` with no --env-file); config comes from the deploy stack environment.