### PR TITLE
chore(client): allow rendering path when vehicle has no line

### DIFF
--- a/apps/client/src/components/vehicles-map/vehicle-path.tsx
+++ b/apps/client/src/components/vehicles-map/vehicle-path.tsx
@@ -261,7 +261,7 @@ export function VehiclePath({ journeyId, lineId }: VehiclePathProps) {
 	);
 
 	const geojson = useMemo<GeoJSON.FeatureCollection>(() => {
-		if (pathDisplayMode === "disabled" || line === undefined) {
+		if (pathDisplayMode === "disabled") {
 			return { type: "FeatureCollection", features: [] };
 		}
 


### PR DESCRIPTION
Client refuses to render vehicle path when the vehicle has no line, however providers can set paths for such vehicles.
Color fallbacks were already implemented for this specific case, so there is no reason to gate paths behind the vehicle having a line.

<img width="654" height="374" alt="image" src="https://github.com/user-attachments/assets/da54643d-8994-41b9-b695-4cf6019cc6ed" />
